### PR TITLE
Make branch PDFs have branch name suffix rather than commit suffix.

### DIFF
--- a/.github/workflows/diff.yml
+++ b/.github/workflows/diff.yml
@@ -30,11 +30,11 @@ jobs:
           root_file: ${{ env.target }}.pdf
       - name: Copy to SHA-suffixed file
 
-        run: cp ${{ env.target}}.pdf ${{ env.target}}-${ steps.extract_head.outputs.branch }-vs-${ setps.extract_base.outputs.branch }.pdf
+        run: cp ${{ env.target}}.pdf ${{ env.target}}-${ steps.extract_head.outputs.branch }-vs-${ steps.extract_base.outputs.branch }.pdf
       - name: Store compiled PDF artifact
         if: success()
         uses: actions/upload-artifact@v2
         with:
-          name: ${{ env.target}}-${ steps.extract_head.outputs.branch }-vs-${ setps.extract_base.outputs.branch }.pdf
-          path: ${{ env.target}}-${ steps.extract_head.outputs.branch }-vs-${ setps.extract_base.outputs.branch }.pdf
+          name: ${{ env.target}}-${ steps.extract_head.outputs.branch }-vs-${ steps.extract_base.outputs.branch }.pdf
+          path: ${{ env.target}}-${ steps.extract_head.outputs.branch }-vs-${ steps.extract_base.outputs.branch }.pdf
           if-no-files-found: error

--- a/.github/workflows/diff.yml
+++ b/.github/workflows/diff.yml
@@ -20,7 +20,7 @@ jobs:
         run: echo "##[set-output name=file;]$(echo ${{ env.target}}-${ steps.extract_head.outputs.branch }-vs-${ steps.extract_base.outputs.branch }.pdf)"
       - name: Check DIFF file name
         shell: bash
-        run: echo ${ steps.diff.outputs.file } >&2
+        run: echo ${{ steps.diff.outputs.file }} >&2
       - name: Set up Git repository
         uses: actions/checkout@v2
         with:
@@ -37,11 +37,11 @@ jobs:
           root_file: ${{ env.target }}.pdf
       - name: Copy to SHA-suffixed file
 
-        run: cp ${{ env.target}}.pdf ${{ env.target}}-${ steps.extract_head.outputs.branch }-vs-${ steps.extract_base.outputs.branch }.pdf
+        run: cp ${{ env.target}}.pdf ${{ steps.diff.outputs.file }}
       - name: Store compiled PDF artifact
         if: success()
         uses: actions/upload-artifact@v2
         with:
-          name: ${{ env.target}}-${ steps.extract_head.outputs.branch }-vs-${ steps.extract_base.outputs.branch }.pdf
-          path: ${{ env.target}}-${ steps.extract_head.outputs.branch }-vs-${ steps.extract_base.outputs.branch }.pdf
+          name: ${{ steps.diff.outputs.file }}
+          path: ${{ steps.diff.outputs.file }}
           if-no-files-found: error

--- a/.github/workflows/diff.yml
+++ b/.github/workflows/diff.yml
@@ -20,7 +20,7 @@ jobs:
         run: echo "##[set-output name=file;]$(echo ${{ env.target}}-${ steps.extract_head.outputs.branch }-vs-${ steps.extract_base.outputs.branch }.pdf)"
       - name: Check DIFF file name
         shell: bash
-        run: echo ${ steps.diff.file } >&2
+        run: echo ${ steps.diff.outputs.file } >&2
       - name: Set up Git repository
         uses: actions/checkout@v2
         with:

--- a/.github/workflows/diff.yml
+++ b/.github/workflows/diff.yml
@@ -6,6 +6,14 @@ jobs:
   build-diff-pdf:
     runs-on: ubuntu-latest
     steps:
+      - name: Extract base name
+        shell: bash
+        run: echo "##[set-output name=branch;]$(with_slashes=${{ github.base_ref#refs/heads/}}; echo ${with_slashes//\//-})"
+        id: extract_base
+      - name: Extract head name
+        shell: bash
+        run: echo "##[set-output name=branch;]$(with_slashes=${{ github.head_ref#refs/heads/}}; echo ${with_slashes//\//-})"
+        id: extract_head
       - name: Set up Git repository
         uses: actions/checkout@v2
         with:
@@ -22,11 +30,11 @@ jobs:
           root_file: ${{ env.target }}.pdf
       - name: Copy to SHA-suffixed file
 
-        run: cp ${{ env.target}}.pdf ${{ env.target}}-${{ github.head_ref }}-vs-${{ github.base_ref }}.pdf
+        run: cp ${{ env.target}}.pdf ${{ env.target}}-${ steps.extract_head.outputs.branch }-vs-${ setps.extract_base.outputs.branch }.pdf
       - name: Store compiled PDF artifact
         if: success()
         uses: actions/upload-artifact@v2
         with:
-          name: ${{ env.target}}-${{ github.head_ref }}-vs-${{ github.base_ref }}.pdf
-          path: ${{ env.target}}-${{ github.head_ref }}-vs-${{ github.base_ref }}.pdf
+          name: ${{ env.target}}-${ steps.extract_head.outputs.branch }-vs-${ setps.extract_base.outputs.branch }.pdf
+          path: ${{ env.target}}-${ steps.extract_head.outputs.branch }-vs-${ setps.extract_base.outputs.branch }.pdf
           if-no-files-found: error

--- a/.github/workflows/diff.yml
+++ b/.github/workflows/diff.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Create DIFF file name
         id: diff
         shell: bash
-        run: echo "##[set-output name=file;]$(echo ${{ env.target}}-${ steps.extract_head.outputs.branch }-vs-${ steps.extract_base.outputs.branch }.pdf)"
+        run: echo "##[set-output name=file;]$(echo ${{ env.target}}-${{ steps.extract_head.outputs.branch }}-vs-${{ steps.extract_base.outputs.branch }}.pdf)"
       - name: Check DIFF file name
         shell: bash
         run: echo ${{ steps.diff.outputs.file }} >&2

--- a/.github/workflows/diff.yml
+++ b/.github/workflows/diff.yml
@@ -8,11 +8,11 @@ jobs:
     steps:
       - name: Extract base name
         shell: bash
-        run: echo "##[set-output name=branch;]$(with_slashes=${{ github.base_ref#refs/heads/}}; echo ${with_slashes//\//-})"
+        run: echo "##[set-output name=branch;]$(base_ref=${{ github.base_ref }}; with_slashes=${base_ref#refs/heads/}; echo ${with_slashes//\//-})"
         id: extract_base
       - name: Extract head name
         shell: bash
-        run: echo "##[set-output name=branch;]$(with_slashes=${{ github.head_ref#refs/heads/}}; echo ${with_slashes//\//-})"
+        run: echo "##[set-output name=branch;]$(head_ref=${{ github.head_ref }}; with_slashes=${head_ref#refs/heads/}; echo ${with_slashes//\//-})"
         id: extract_head
       - name: Set up Git repository
         uses: actions/checkout@v2

--- a/.github/workflows/diff.yml
+++ b/.github/workflows/diff.yml
@@ -14,6 +14,13 @@ jobs:
         shell: bash
         run: echo "##[set-output name=branch;]$(head_ref=${{ github.head_ref }}; with_slashes=${head_ref#refs/heads/}; echo ${with_slashes//\//-})"
         id: extract_head
+      - name: Create DIFF file name
+        id: diff
+        shell: bash
+        run: echo "##[set-output name=file;]$(echo ${{ env.target}}-${ steps.extract_head.outputs.branch }-vs-${ steps.extract_base.outputs.branch }.pdf)"
+      - name: Check DIFF file name
+        shell: bash
+        run: echo ${ steps.diff.file } >&2
       - name: Set up Git repository
         uses: actions/checkout@v2
         with:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -9,7 +9,7 @@ jobs:
     steps:
       - name: Extract branch name
         shell: bash
-        run: echo "##[set-output name=branch;]$(echo ${GITHUB_REF#refs/heads/})"
+        run: echo "##[set-output name=branch;]$(with_slashes=${GITHUB_REF#refs/heads/}; echo ${with_slashes//\//-})"
         id: extract_branch
       - name: Set up Git repository
         uses: actions/checkout@v2

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -7,6 +7,10 @@ jobs:
   build-head-pdf:
     runs-on: ubuntu-latest
     steps:
+      - name: Extract branch name
+        shell: bash
+        run: echo "##[set-output name=branch;]$(echo ${GITHUB_REF#refs/heads/})"
+        id: extract_branch
       - name: Set up Git repository
         uses: actions/checkout@v2
         with:
@@ -18,11 +22,11 @@ jobs:
           args: VERBOSE=1 TARGET=${{ env.target }}
           root_file: ${{ env.target }}.pdf
       - name: Copy to ref-suffixed file
-        run: cp ${{ env.target }}.pdf ${{ env.target }}-${{ github.sha }}.pdf
+        run: cp ${{ env.target }}.pdf ${{ env.target }}-${{ steps.extract_branch.outputs.branch }}.pdf
       - name: Store compiled PDF artifact
         if: success()
         uses: actions/upload-artifact@v2
         with:
-          name: ${{ env.target }}-${{ github.sha }}.pdf
-          path: ${{ env.target }}-${{ github.sha }}.pdf
+          name: ${{ env.target }}-${{ steps.extract_branch.outputs.branch }}.pdf
+          path: ${{ env.target }}-${{ steps.extract_branch.outputs.branch }}.pdf
           if-no-files-found: error


### PR DESCRIPTION
 - Use a bash snippet to get the branch name.
 - Make sure to avoid incorporating slashes in branch name into the artifact name, which would mistakenly suggest subdirectories.